### PR TITLE
Bug 1529175 - update our arc fork to skip specific prompts; r=zalun

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1086,7 +1086,7 @@ EOTEXT
       $file_list = '    '.implode("\n    ", $file_list);
       echo $file_list;
 
-      if (!phutil_console_confirm($confirm, $default_no = false)) {
+      if (!$this->mozPhabConfirm($confirm) && !phutil_console_confirm($confirm, $default_no = false)) {
         throw new ArcanistUsageException(pht('Aborted workflow to fix UTF-8.'));
       } else {
         foreach ($utf8_problems as $change) {
@@ -1870,7 +1870,7 @@ EOTEXT
               $list->drawConsoleString());
 
             $confirm = pht('Continue even though reviewers are unavailable?');
-            if (!phutil_console_confirm($confirm)) {
+            if (!$this->mozPhabConfirm($confirm) && !phutil_console_confirm($confirm)) {
               throw new ArcanistUsageException(
                 pht('Specify available reviewers and retry.'));
             }
@@ -2996,6 +2996,16 @@ EOTEXT
       phlog($ex);
       return false;
     }
+  }
+
+  private function mozPhabConfirm($message) {
+    // When called from moz-phab just display the confirmation message and
+    // return `true`.
+    if (!getenv("MOZPHAB")) {
+      return false;
+    }
+    echo "\n" . phutil_console_wrap($message.' ', 4) . "Yes\n\n";
+    return true;
   }
 
 }


### PR DESCRIPTION
Skip specific prompts when the `MOZPHAB` environmental variable is set:

Bug 1521980 - Invalid Content Encoding (Non-UTF8)
* Non-UTF8 files will automatically be marked as binary

Bug 1528965 - -f does not bypass arc unavailable reviewers check
* Permits unavailable reviewers